### PR TITLE
add macro for intentional assert

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -89,3 +89,25 @@ where
         self.as_mut().expect(msg)
     }
 }
+
+#[macro_export]
+macro_rules! intentional {
+    ($expr:expr) => {
+        $crate::Assert::assert_expected($expr)
+    };
+    ($expr:expr, $msg:expr) => {
+        $crate::Assert::assert($expr, $msg)
+    };
+}
+
+#[test]
+fn intentional() {
+    struct NonCopy;
+    let option = Some("string");
+    let _: &str = intentional!(option);
+    let _: &str = intentional!(option, "msg");
+    let result = Ok::<_, ()>(NonCopy);
+    let _: &NonCopy = intentional!(&result);
+    let _ = intentional!(result);
+    intentional!(true);
+}


### PR DESCRIPTION
- [ ] reconsider name
- [ ] add doc
- [ ] might make sense to add format arguments? Though this would require the trait to have another (maybe hidden) function `get_expected(self) -> Option<Expected>`. Also, this string should seldom be actually printed.
